### PR TITLE
Use the code from the source repos now the patch is merged

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set production environment
         run: sh ./.github/workflows/set_environment.sh {{ secrets.API_URL }}
       - name: deploy web app
-        uses: Loefbijter/angular-deploy-gh-pages-actions@test
+        uses: AhsanAyaz/angular-deploy-gh-pages-actions@v1.3.1
         with:
           github_access_token: ${{ secrets.ACCESS_TOKEN }} # see the Configuration section for how you can create secrets
           deploy_branch: gh-pages # The branch the action should deploy to.


### PR DESCRIPTION
## Description
Currently, https://github.com/Loefbijter/angular-deploy-gh-pages-actions is being used. But in https://github.com/AhsanAyaz/angular-deploy-gh-pages-actions/pull/19 The patch that was needed was merged upstream. therefore, the loefbijter fork is not needed anymore. This PR changes that.