### PR TITLE
Activity create image preset + date improvement

### DIFF
--- a/src/app/activities/activity.model.ts
+++ b/src/app/activities/activity.model.ts
@@ -59,3 +59,8 @@ export interface Answer {
   questionId: string;
   text: string;
 }
+
+export interface ActivityImage {
+  name: string;
+  url: string;
+}

--- a/src/app/activities/create-activity-dialog/create-activity-dialog.component.html
+++ b/src/app/activities/create-activity-dialog/create-activity-dialog.component.html
@@ -12,8 +12,8 @@
 
   <p>
     <mat-form-field>
-      <input type="text" matInput placeholder="{{'activity.description.placeholder' | content}}"
-        formControlName="description">
+      <textarea matInput placeholder="{{'activity.description.placeholder' | content}}"
+                formControlName="description"></textarea>
     </mat-form-field>
     <app-form-errors [targetFormControl]="createActivityForm.controls.description" [messages]="errors.description"
       (errorChanges)="updateErrors('description', $event)">
@@ -32,8 +32,9 @@
 
   <p>
     <mat-form-field>
+      <mat-label>{{'activity.imageUrl.placeholder' | content}}</mat-label>
       <mat-select formControlName="image">
-        <mat-option *ngFor="let image of images">{{ image.name }}</mat-option>
+        <mat-option *ngFor="let image of images" [value]="image.url">{{ image.name }}</mat-option>
       </mat-select>
     </mat-form-field>
     <app-form-errors [targetFormControl]="createActivityForm.controls.image" [messages]="errors.image"
@@ -55,9 +56,9 @@
   <div>
     <mat-form-field>
       <input matInput [ngxMatDatetimePicker]="startTimePicker"
-        placeholder="{{'activity.startTime.placeholder' | content}}" formControlName="startTime">
+        placeholder="{{'activity.startTime.placeholder' | content}}" formControlName="startTime" (dateChange)="patchDate()">
       <mat-datepicker-toggle matSuffix [for]="startTimePicker"></mat-datepicker-toggle>
-      <ngx-mat-datetime-picker #startTimePicker [showSpinners]="true"></ngx-mat-datetime-picker>
+      <ngx-mat-datetime-picker #startTimePicker [showSpinners]="true" [showSeconds]="false"></ngx-mat-datetime-picker>
     </mat-form-field>
     <app-form-errors [targetFormControl]="createActivityForm.controls.startTime" [messages]="errors.startTime"
       (errorChanges)="updateErrors('startTime', $event)">

--- a/src/app/activities/create-activity-dialog/create-activity-dialog.component.html
+++ b/src/app/activities/create-activity-dialog/create-activity-dialog.component.html
@@ -32,13 +32,14 @@
 
   <p>
     <mat-form-field>
-      <input type="imageUrl" matInput placeholder="{{'activity.imageUrl.placeholder' | content}}"
-        formControlName="imageUrl">
+      <mat-select formControlName="image">
+        <mat-option *ngFor="let image of images">{{ image.name }}</mat-option>
+      </mat-select>
     </mat-form-field>
-    <app-form-errors [targetFormControl]="createActivityForm.controls.imageUrl" [messages]="errors.imageUrl"
-      (errorChanges)="updateErrors('imageUrl', $event)">
+    <app-form-errors [targetFormControl]="createActivityForm.controls.image" [messages]="errors.image"
+      (errorChanges)="updateErrors('image', $event)">
     </app-form-errors>
-    <img [src]="createActivityForm.controls.imageUrl.value" alt="{{'activity.image-preview.text' | content}}">
+    <img [src]="createActivityForm.controls.image.value" alt="{{'activity.image-preview.text' | content}}">
   </p>
 
   <p>

--- a/src/app/activities/create-activity-dialog/create-activity-dialog.component.ts
+++ b/src/app/activities/create-activity-dialog/create-activity-dialog.component.ts
@@ -16,6 +16,8 @@ import {
   checkIfActiveFromIsInPast,
   checkIfActiveUntilBeforeEndTime,
 } from '../activities.validators';
+import { isMoment } from 'moment';
+import * as moment from 'moment/moment';
 
 @Component({
   selector: 'app-create-activity-dialog',
@@ -44,7 +46,7 @@ export class CreateActivityDialogComponent implements OnInit {
     this.imagesService.getImages().subscribe({
       next: images => {
         console.log(images);
-        this.images = images;
+        this.images = images['images'];
       }
     });
 
@@ -103,6 +105,19 @@ export class CreateActivityDialogComponent implements OnInit {
           this.dialogRef.disableClose = false;
         }
       });
+    }
+  }
+
+  public patchDate(): void {
+    console.log('We do be patching!');
+    const seconds: moment.Duration = moment.duration(this.createActivityForm.controls.startTime.value.seconds(), 's');
+    this.createActivityForm.controls.startTime.value.subtract(seconds);
+    this.createActivityForm.controls.startTime.patchValue(this.createActivityForm.controls.startTime.value);
+    if (this.createActivityForm.controls.endTime.value == '') {
+      const oneHour: moment.Duration = moment.duration(1, 'h');
+      const endTime: moment.Moment = this.createActivityForm.controls.startTime.value.clone();
+      endTime.add(oneHour);
+      this.createActivityForm.controls.endTime.patchValue(endTime);
     }
   }
 

--- a/src/app/activities/create-activity-dialog/create-activity-dialog.component.ts
+++ b/src/app/activities/create-activity-dialog/create-activity-dialog.component.ts
@@ -5,8 +5,9 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ContentService } from '../../_modules/content/content.service';
 import { FormErrorsService } from '../../_modules/form-errors/form-errors.service';
+import { ImagesService } from '../images.service';
 import { URL_REGEX, TOAST_DURATION } from '../../constants';
-import { Activity, CreateActivityDto } from '../activity.model';
+import { Activity, ActivityImage, CreateActivityDto } from '../activity.model';
 import {
   checkIfEndTimeAfterStartTime,
   checkIfActiveFromBeforeStartTime,
@@ -26,6 +27,7 @@ export class CreateActivityDialogComponent implements OnInit {
   public loading: boolean = false;
   public createActivityForm: FormGroup;
   public errors: ValidationErrors = { };
+  public images: ActivityImage[] = [];
 
   public constructor(
     public readonly dialogRef: MatDialogRef<CreateActivityDialogComponent>,
@@ -34,14 +36,23 @@ export class CreateActivityDialogComponent implements OnInit {
     private readonly contentService: ContentService,
     private readonly formErrorsService: FormErrorsService,
     private readonly activityService: ActivitiesService,
+    private readonly imagesService: ImagesService,
   ) { }
 
   public ngOnInit(): void {
+
+    this.imagesService.getImages().subscribe({
+      next: images => {
+        console.log(images);
+        this.images = images;
+      }
+    });
+
     this.createActivityForm = this.fb.group({
       title: new FormControl('', { validators: [Validators.required, Validators.maxLength(255)] }),
       description: new FormControl('', { validators: [Validators.required] }),
       location: new FormControl('', { validators: [Validators.required] }),
-      imageUrl: new FormControl('', { validators: [Validators.required, Validators.pattern(URL_REGEX)] }),
+      image: new FormControl('', { validators: [Validators.required] }),
       organiser: new FormControl(''),
       startTime: new FormControl('', { validators: [Validators.required, checkIfStartTimeIsInPast] }),
       endTime: new FormControl('', { validators: [Validators.required] }),

--- a/src/app/activities/create-activity-dialog/create-activity-dialog.component.ts
+++ b/src/app/activities/create-activity-dialog/create-activity-dialog.component.ts
@@ -45,7 +45,6 @@ export class CreateActivityDialogComponent implements OnInit {
 
     this.imagesService.getImages().subscribe({
       next: images => {
-        console.log(images);
         this.images = images['images'];
       }
     });
@@ -109,7 +108,6 @@ export class CreateActivityDialogComponent implements OnInit {
   }
 
   public patchDate(): void {
-    console.log('We do be patching!');
     const seconds: moment.Duration = moment.duration(this.createActivityForm.controls.startTime.value.seconds(), 's');
     this.createActivityForm.controls.startTime.value.subtract(seconds);
     this.createActivityForm.controls.startTime.patchValue(this.createActivityForm.controls.startTime.value);

--- a/src/app/activities/images.service.ts
+++ b/src/app/activities/images.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { ActivityImage } from './activity.model';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ImagesService {
+
+  public itemsTotal: number = undefined;
+
+  public constructor(private readonly http: HttpClient) { }
+
+  public getImages(): Observable<ActivityImage[]> {
+    return this.http.get<ActivityImage[]>('https://images.loefbijter.nl/evenementen/images.json');
+  }
+
+}


### PR DESCRIPTION
## Description
This change makes creating activities a little bit easier by:
- Providing a list of activity images that can be chosen from.
- Automatically setting seconds to zero when setting the activity start time.
- Automatically setting the end time to start time + 1 hour.

## Depending pull requests


## Related issues


### Checklist
- [ ] Meets acceptance criteria
- [ ] Added tests
- [ ] All tests are working
- [ ] Fixed linting warnings
